### PR TITLE
Configuration to allow for SSL to work

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,5 @@ AWS_REGION=AWSRegionForCognito (e.g. eu-west-2)
 AWS_COGNITO_APP_CLIENT_ID=MySampleClientId
 AWS_COGNITO_APP_CLIENT_SECRET=MySampleClientIdSecret
 
-
-
-
+# Load Balancer Config
+LOAD_BALANCER_SSL=False

--- a/family_context/settings.py
+++ b/family_context/settings.py
@@ -36,6 +36,10 @@ CSRF_TRUSTED_ORIGINS = config(
     "TRUSTED_ORIGINS", cast=lambda v: [s.strip() for s in v.split(",")], default="https://127.0.0.1"
 )
 
+# Check if setting is set to allow this to run behind a load balancer
+LOAD_BALANCER_SSL = config("LOAD_BALANCER_SSL", default=False, cast=bool)
+if LOAD_BALANCER_SSL:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 


### PR DESCRIPTION
This setting allows the website to assume traffic is coming from https even though a certificate isn't available. This is only recommended to use if the website is run from behind a load balancer that handles the traffic.