### PR TITLE
Added switching to allow for local development without SSO

### DIFF
--- a/family_context/settings.py
+++ b/family_context/settings.py
@@ -86,7 +86,9 @@ COGNITO_CLIENT_SECRET = config(
     "AWS_COGNITO_APP_CLIENT_SECRET", default=False
 )
 
-if COGNITO_DOMAIN and AWS_REGION and COGNITO_CLIENT_ID and COGNITO_CLIENT_SECRET:
+SSO_USED = COGNITO_DOMAIN and AWS_REGION and COGNITO_CLIENT_ID and COGNITO_CLIENT_SECRET
+
+if SSO_USED:
     SOCIALACCOUNT_PROVIDERS = {
         "amazon_cognito": {
             "APP": {
@@ -122,7 +124,6 @@ TEMPLATES = [
         },
     },
 ]
-
 WSGI_APPLICATION = "family_context.wsgi.application"
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"

--- a/family_context/urls.py
+++ b/family_context/urls.py
@@ -7,9 +7,13 @@ from .views import Home
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("core.urls")),
-    path("accounts/", include("allauth.urls")),
     path("home/", Home.as_view(), name="home"),
 ]
+
+if settings.SSO_USED:
+    urlpatterns.append(path("accounts/", include("allauth.urls")))
+else:
+    urlpatterns.append(path("accounts/", include("django.contrib.auth.urls")))
 
 if settings.DEBUG:
     urlpatterns += static(


### PR DESCRIPTION
Allow for the SSO login page to be present if SSO configuration is in place.
If not, use the built in Django login page.